### PR TITLE
Do not return error from -i when no interfaces are configured

### DIFF
--- a/resolvconf.in
+++ b/resolvconf.in
@@ -440,6 +440,8 @@ list_resolv()
 
 	cmd="$1"
 	shift
+	pattern_specified="$1"
+
 	excl=false
 	list=
 	report=false
@@ -470,7 +472,7 @@ list_resolv()
 
 	# If we have an interface ordering list, then use that.
 	# It works by just using pathname expansion in the interface directory.
-	if [ -n "$1" ]; then
+	if [ -n "$pattern_specified" ]; then
 		list="$*"
 		$force || report=true
 	elif ! $excl; then
@@ -523,7 +525,11 @@ list_resolv()
 	fi
 
 	cd "$IFACEDIR"
-	retval=1
+	if [ -n "$pattern_specified" ]; then
+		retval=1
+	else
+		retval=0
+	fi
 	for i in $(uniqify $list); do
 		# Only list interfaces which we really have
 		if ! [ -f "$i" ]; then


### PR DESCRIPTION
Thhe -i and -l options have an optional pattern argument, and it makes sense to return an error when the pattern does not match.

However, when no pattern is specified and no interface is configured an error is returned as well.

This makes it problematic to detect if -i option is supported - an error is returned both when the option is not supported by other resolvconf implementation, and when there are no interfaces configured in openresolv.
