### PR TITLE
Suppress error in S6 systems other than Artix

### DIFF
--- a/resolvconf.in
+++ b/resolvconf.in
@@ -329,7 +329,7 @@ detect_init()
 		   fi'
 	elif [ -x /usr/bin/s6-rc ] && [ -x /usr/bin/s6-svc ]; then
 		RESTARTCMD='
-		   if s6-rc -a list | grep -qFx $1-srv
+		   if s6-rc -a list 2>/dev/null | grep -qFx $1-srv
 		   then
 			s6-svc -r /run/service/$1-srv
 		   fi'


### PR DESCRIPTION
If the command `s6-rc -a list` is run on a system utilizing S6 supervisor during init, it fails with error `s6-rc: fatal: unable to take locks: Resource busy` because the s6-rc database is locked during init. If it is run post-init, it returns a list of active services successfully. The change was introduced in PR https://github.com/NetworkConfiguration/openresolv/pull/12 to add support for Artix linux, but it creates an issue for non-Artix S6 users who rely on openresolv during init steps.

This proposed change suppresses the error and should not have any impact on the function. If resolvectl is called during init, the grep in the if statement will return false without error and RESTARTCMD won't be set (as expected) as there shouldn't be any Artix service to restart anyway.