### PR TITLE
resolvconf.conf.5.in: multiple-entries name_servers syntax

### DIFF
--- a/resolvconf.conf.5.in
+++ b/resolvconf.conf.5.in
@@ -98,7 +98,12 @@ To remove a sub domain, you can use *.bar
 .It Sy name_servers
 Prepend name servers to the dynamically generated list.
 You should set this to 127.0.0.1 if you use a local name server other than
-libc.
+libc. Multiple entries should be double-quoted and space-separated.
+.Pp
+Example resolvconf.conf for multiple name servers:
+.Bd -compact -literal -offset indent
+name_servers="198.51.100.1 198.51.100.2"
+.Ed
 .It Sy name_servers_append
 Append name servers to the dynamically generated list.
 .It Sy name_server_blacklist


### PR DESCRIPTION
Clarify the syntax to be used to specify multiple name servers in a name_servers directive.

Close #31 